### PR TITLE
Updated packages - removing geany

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -40,8 +40,6 @@ findsploit
 firefox
 gcc
 gdb
-geany
-geany-plugins
 gobuster
 grml-zsh-config
 gvim


### PR DESCRIPTION
Geany is not the greatest text editor and an awful IDE. @berzerk0 will put in better fits.