### PR TITLE
Updated README.md - Build as Root

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 ## Building the Image
 
-Clone the repo and run the following:
+Clone the repo and run the following **as root**:
 
 ```
-cd blackarch-slim-iso
-rm -rfv out work
-mkdir out work
-./build.sh -v
+# cd blackarch-slim-iso
+# rm -rfv out work
+# mkdir out work
+# ./build.sh -v
 ```
 
 The finished ISO will be located in the `out` folder.


### PR DESCRIPTION
Updated README.md to clarify that the build commands must be run as root.